### PR TITLE
Change 'Test Suits' to 'Test Suites'

### DIFF
--- a/src/renderer/components/topbar/test-summary.tsx
+++ b/src/renderer/components/topbar/test-summary.tsx
@@ -69,7 +69,7 @@ function TestSummary({ totalResult, workspace }: TestSummaryProps) {
     <Container>
       <div>Execution Summary</div>
       <Row>
-        <span>Test Suits</span>
+        <span>Test Suites</span>
         <ResultContainer>
           <Success>
             {getLabel(totalResult.numPassedTestSuites)}


### PR DESCRIPTION
Fix for Issue #26 - Typo - Execution Summary "Test Suits" heading should be "Test Suites"