### PR TITLE
feat(menu): Add File subsection with Open Project and Exit

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,5 +1,4 @@
 import { app, Menu, shell, BrowserWindow } from "electron";
-
 export default class MenuBuilder {
   mainWindow: BrowserWindow;
   constructor(mainWindow) {
@@ -12,7 +11,7 @@ export default class MenuBuilder {
     if (process.platform === "darwin") {
       template = this.buildDarwinTemplate();
     } else {
-      template = [this.buildDefaultTemplate()];
+      template = [this.buildFileTemplate(), this.buildHelpTemplate()];
     }
 
     const menu = Menu.buildFromTemplate(template);
@@ -46,10 +45,33 @@ export default class MenuBuilder {
       ]
     };
 
-    return [EditMenu, this.buildDefaultTemplate()];
+    return [EditMenu, this.buildFileTemplate(), this.buildHelpTemplate()];
+  }
+  buildFileTemplate() {
+    const fileTemplate = {
+      label: "File",
+      submenu: [
+        {
+          label: "Open Project...",
+          click: () => {
+            //Fire a message to the renderer process.
+            //Handled in stores/Workspace
+            this.mainWindow.webContents.send("openProject");
+          }
+        },
+        {
+          label: "Exit",
+          click: () => {
+            this.mainWindow.close();
+          }
+        }
+      ]
+    };
+
+    return fileTemplate;
   }
 
-  buildDefaultTemplate() {
+  buildHelpTemplate() {
     const helpTemplate = {
       label: "Help",
       submenu: [

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -53,6 +53,7 @@ export default class MenuBuilder {
       submenu: [
         {
           label: "Open Project...",
+          accelerator: "CmdOrCtrl+O",
           click: () => {
             //Fire a message to the renderer process.
             //Handled in stores/Workspace

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -63,7 +63,7 @@ export default class MenuBuilder {
         {
           label: "Exit",
           click: () => {
-            this.mainWindow.close();
+            app.quit();
           }
         }
       ]

--- a/src/renderer/stores/Workspace.ts
+++ b/src/renderer/stores/Workspace.ts
@@ -13,6 +13,8 @@ import { processCoverageTree } from "../util/coverage-files";
 import launchEditor from "react-dev-utils/launchEditor";
 import { isPackageJSONExists } from "../util/workspace";
 import { openProjectFolder } from "../util/electron";
+import {ipcRenderer} from 'electron';
+
 
 export class Workspace {
   @observable runner: Runner;
@@ -59,6 +61,10 @@ export class Workspace {
       this.showSidebar = !this.showSidebar;
       return false;
     });
+    //Listen for event from main process. 
+    ipcRenderer.on('openProject', () => {
+      this.openProject();
+  });
   }
 
   initializeRunner() {

--- a/src/renderer/stores/Workspace.ts
+++ b/src/renderer/stores/Workspace.ts
@@ -61,6 +61,10 @@ export class Workspace {
       this.showSidebar = !this.showSidebar;
       return false;
     });
+    Mousetrap.bind(["command+o", "ctrl+o"], () => {
+      this.openProject();
+      return false;
+    });
     //Listen for event from main process. 
     ipcRenderer.on('openProject', () => {
       this.openProject();

--- a/src/renderer/stores/Workspace.ts
+++ b/src/renderer/stores/Workspace.ts
@@ -154,6 +154,9 @@ export class Workspace {
 
   openProject() {
     openProjectFolder().then((projectDirectory: string[]) => {
+      if (this.isProjectAvailable) {
+        this.closeProject();     
+      }       
       const rootPath = projectDirectory[0];
       if (this.validateProject(rootPath)) {
         this.preference.initialize(rootPath);


### PR DESCRIPTION
Project switching works now. 

Would be good if someone else can test it (until we have some automated tests).

Steps:

1. Open a project. (Either by the button on the open screen, or via the new toolbar menu.
2. Confirm this project is open. Now open another project via the toolbar menu.
3. Confirm it has switched to the new project.

The exit button is pretty easy to test. :)