### PR TITLE
Add stop/play tooltips

### DIFF
--- a/src/renderer/components/topbar/run-panel/panel.tsx
+++ b/src/renderer/components/topbar/run-panel/panel.tsx
@@ -34,7 +34,7 @@ const ButtonsContainer = styled.div`
   border-radius: 3px;
 `;
 
-function runButonLabel(isRunning, isWatching) {
+function runButtonLabel(isRunning, isWatching) {
   if (isWatching) {
     return isRunning ? "Running" : "Rerun all tests";
   } else {
@@ -54,16 +54,21 @@ function RunPanel({ workspace }: RunPanelProps) {
       <Info workspace={workspace} />
       <ButtonsContainer>
         <ButtonGroup className="pt-button-group pt-minimal">
-          <a
-            className={cn("pt-button  pt-minimal pt-icon-play", {
-              "pt-disabled": isRunning
-            })}
-            onClick={() => {
-              workspace.runProject();
-            }}
+          <Tooltip2
+            content={runButtonLabel(isRunning, isWatching)}
+            inline={true}
+            intent={Intent.PRIMARY}
+            placement="bottom"
           >
-            {runButonLabel(isRunning, isWatching)}
-          </a>
+            <a
+              className={cn("pt-button  pt-minimal pt-icon-play", {
+                "pt-disabled": isRunning
+              })}
+              onClick={() => {
+                workspace.runProject();
+              }}
+            />
+          </Tooltip2>
           <Tooltip2
             content="Stop tests"
             inline={true}

--- a/src/renderer/components/topbar/run-panel/panel.tsx
+++ b/src/renderer/components/topbar/run-panel/panel.tsx
@@ -64,14 +64,21 @@ function RunPanel({ workspace }: RunPanelProps) {
           >
             {runButonLabel(isRunning, isWatching)}
           </a>
-          <a
-            className={cn("pt-button pt-icon-stop", {
-              "pt-disabled": !isRunning && !isWatching
-            })}
-            onClick={() => {
-              workspace.stop();
-            }}
-          />
+          <Tooltip2
+            content="Stop tests"
+            inline={true}
+            intent={Intent.PRIMARY}
+            placement="bottom"
+          >
+            <a
+              className={cn("pt-button pt-icon-stop", {
+                "pt-disabled": !isRunning && !isWatching
+              })}
+              onClick={() => {
+                workspace.stop();
+              }}
+            />
+          </Tooltip2>
           <Tooltip2
             content="Close project"
             inline={true}


### PR DESCRIPTION
Refactored the run tests text into the tooltip to match other buttons, and added tooltips for stop/play.

Looks like this now: 

![pic1maj](https://user-images.githubusercontent.com/9067274/34634902-dfbeffc6-f2dc-11e7-95b8-e39db6a36a97.PNG)

![pic2maj](https://user-images.githubusercontent.com/9067274/34634903-e3c52e2e-f2dc-11e7-972a-0ae31f557c21.PNG)
![majpic2](https://user-images.githubusercontent.com/9067274/34634904-e5b0f61e-f2dc-11e7-9590-2f8d99721408.PNG)



