### PR TITLE
Search dismiss

### DIFF
--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -6,6 +6,7 @@ import Sidebar from "./sidebar";
 import TestFile from "./test-file";
 import APP from "./app.gql";
 import WORKSPACE from "./query.gql";
+import useKeys from "./hooks/use-keys";
 import useSubscription from "./test-file/use-subscription";
 import SUMMARY_QUERY from "./summary-query.gql";
 import SUMMARY_SUBS from "./summary-subscription.gql";
@@ -83,6 +84,10 @@ export default function App() {
   const stopRunner = useMutation(STOP_RUNNER);
 
   const [isSearchOpen, setSearchOpen] = useState(false);
+  const keys = useKeys();
+  if (isSearchOpen && keys.has('Escape')) {
+    setSearchOpen(false);
+  }
 
   return (
     <ContainerDiv>

--- a/ui/hooks/use-keys.ts
+++ b/ui/hooks/use-keys.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+export default function useKeys() {
+  const [keys, setKeys] = useState(new Map());
+
+  function downHandler({ key }:KeyboardEvent) {
+    keys.set(key, true);
+    setKeys(keys);
+  }
+
+  const upHandler = ({ key }:KeyboardEvent) => {
+    keys.delete(key);
+    setKeys(keys);
+  };
+
+  useEffect(() => {
+    window.addEventListener("keydown", downHandler);
+    window.addEventListener("keyup", upHandler);
+    return () => {
+      window.removeEventListener("keydown", downHandler);
+      window.removeEventListener("keyup", upHandler);
+    };
+  }, []);
+
+  return keys;
+}

--- a/ui/search/index.tsx
+++ b/ui/search/index.tsx
@@ -103,8 +103,9 @@ export function Search({
             .filter(file =>
               file.path.toLowerCase().includes(query.toLowerCase())
             )
-            .map((file: any) => (
+            .map((file: any, index: number) => (
               <ItemContainer
+                key={index}
                 onClick={() => {
                   onItemClick(file.path);
                 }}

--- a/ui/search/index.tsx
+++ b/ui/search/index.tsx
@@ -101,7 +101,7 @@ export function Search({
         <SearchBox
           ref={searchBoxRef}
           value={query}
-          placeholder="Start searching..."
+          placeholder="Start searching…"
           onChange={(event: any) => {
             setQuery(event.target.value);
           }}

--- a/ui/search/index.tsx
+++ b/ui/search/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { Item } from "../../server/api/workspace/tree";
 import { color } from "styled-system";
@@ -85,6 +85,13 @@ export function Search({
   const onlyFiles = files.filter(file => file.type === "file");
 
   const [query, setQuery] = useState("");
+  const searchBoxRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (searchBoxRef && searchBoxRef.current) {
+      searchBoxRef.current.focus();
+    }
+  }, [show]);
+
   if (!show) return null;
 
   return (
@@ -92,6 +99,7 @@ export function Search({
       <Drop onClick={onClose} />
       <Container bg="dark">
         <SearchBox
+          ref={searchBoxRef}
           value={query}
           placeholder="Start searching..."
           onChange={(event: any) => {


### PR DESCRIPTION
* Fixed missing `key` prop warning in `Search`
* Changed triple period to ellipsis in search input placeholder
* Search input is focused when opened
* Search input can be dismissed by pressing `Escape`

I'd like to add some more keyboard-related shortcuts, but this should serve as a decent starting point for deciding whether this kind of functionality is desired, and if so, how it should be approached.