### PR TITLE
Fixes Issue #73 File Item Names Overflowing Incorrectly

### DIFF
--- a/ui/sidebar/file-item.tsx
+++ b/ui/sidebar/file-item.tsx
@@ -41,6 +41,8 @@ const Label = styled.div`
   margin-left: 5px;
   font-size: 12px;
   overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 `;
 
 const EmptyChevron = styled.div`


### PR DESCRIPTION
Fixes issue #73 where longer file names are breaking file item styling and overflowing onto adjacent file items.  Using VSCode convention of obscuring the overflow text with ellipsis (`...`)

> Majestic file item with ellipsis overflow
<img width="173" alt="fixed-file-item" src="https://user-images.githubusercontent.com/4642404/55100065-58b43680-5097-11e9-9c9f-730a77b852b4.png">

> Majestic sidebar with ellipsis overflow
<img width="302" alt="fixed-sidebar" src="https://user-images.githubusercontent.com/4642404/55100104-6ec1f700-5097-11e9-8673-ce425131ac1d.png">

> VSCode Example
<img width="271" alt="Screen Shot 2019-03-27 at 1 50 00 PM" src="https://user-images.githubusercontent.com/4642404/55100024-42a67600-5097-11e9-8d83-89135baadab4.png">
