### PR TITLE
Handle test.only & describe.only

### DIFF
--- a/integration/projects/basic/test-only.spec.js
+++ b/integration/projects/basic/test-only.spec.js
@@ -1,0 +1,16 @@
+describe("describe", () => {
+  it("it", () => {});
+  test("test", () => {});
+});
+
+describe.only("describe.only", () => {
+  it("it", () => {});
+  test("test", () => {});
+  it.only("it.only", () => {});
+  test.only("test.only", () => {});
+});
+
+fdescribe("fdescribe", () => {
+  it("it", () => {});
+  fit("fit", () => {});
+});

--- a/server/api/workspace/test-item.ts
+++ b/server/api/workspace/test-item.ts
@@ -1,6 +1,6 @@
 import { ObjectType, Field } from "type-graphql";
 
-export type TestItemType = "describe" | "it" | "test";
+export type TestItemType = "describe" | "it";
 
 @ObjectType()
 export class TestItem {
@@ -15,4 +15,7 @@ export class TestItem {
 
   @Field({ nullable: true })
   parent?: string;
+
+  @Field()
+  only: boolean;
 }

--- a/ui/test-file/index.tsx
+++ b/ui/test-file/index.tsx
@@ -52,7 +52,7 @@ function TestFile({ selectedFilePath, isRunning, projectRoot, onStop }: Props) {
   ).length;
 
   const testCount = ((fileItemResult && fileItemResult.items) || []).filter(
-    fileItem => fileItem.type === "it" || fileItem.type === "test"
+    fileItem => fileItem.type === "it"
   ).length;
 
   const runFile = useMutation(RUNFILE, {

--- a/ui/test-file/query.gql
+++ b/ui/test-file/query.gql
@@ -5,6 +5,7 @@ query FileItems($path: String!) {
       name
       type
       parent
+      only
     }
   }
 }

--- a/ui/test-file/test-item.tsx
+++ b/ui/test-file/test-item.tsx
@@ -46,7 +46,7 @@ const Content = styled.div`
   background-color: #262529;
   border-radius: 4px;
   margin-bottom: 10px;
-  border: 1px solid #333437;
+  border: 1px solid ${props => props.only ? "#9d8301" : "#333437"};
 `;
 
 const FailtureMessage = styled.div`
@@ -77,7 +77,7 @@ interface Props {
 }
 
 export default function Test({
-  item: { name, children },
+  item: { name, only, children },
   item,
   result
 }: Props) {
@@ -85,7 +85,7 @@ export default function Test({
   const isDurationAvailable = testResult && testResult.duration !== undefined;
   const haveFailure = testResult && testResult.failureMessages.length > 0;
   const allChildrenPassing = (children || []).every(child => {
-    if (child.type === "it" || child.type === "test") {
+    if (child.type === "it") {
       const childResult = getResults(child, result as any);
       return childResult && childResult.status === "passed";
     }
@@ -93,9 +93,11 @@ export default function Test({
     return true;
   });
 
+  console.log(item);
+
   return (
     <Container>
-      <Content>
+      <Content only={only}>
         <Label>
           <TestIndicator
             status={

--- a/ui/test-file/tranformer.ts
+++ b/ui/test-file/tranformer.ts
@@ -22,6 +22,7 @@ export function transform(
       type: item.type,
       name: item.name,
       parent: item.parent,
+      only: item.only,
       children: nextChildren,
       index: index + 1
     } as any;


### PR DESCRIPTION
`test.only`, `it.only`, `describe.only`, `fit` and `fdescribe` were not showing up in the UI.

In this commit I:
* Refactored `ast/inspector.ts` to ensure they are not excluded
* Added a gold outline to highlight them in the UI