### PR TITLE
add minimum node engine ">=8.0" required in package.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "majestic",
   "version": "1.2.24",
   "engines": {
-    "node": ">=8.0"
+    "node": ">=7.10.1"
   },
   "main": "index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "majestic",
   "version": "1.2.24",
+  "engines": {
+    "node": ">=8.0"
+  },
   "main": "index.js",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
`async` function doesn't work with node 6, so now the application should throw the warning on installation.

https://node.green/#ES2017-features-async-functions