### PR TITLE
fix: jest path should be enclosed with quotes

### DIFF
--- a/server/services/config-resolver.ts
+++ b/server/services/config-resolver.ts
@@ -37,7 +37,7 @@ export default class ConfigResolver {
     }
 
     const majesticConfig = {
-      jestScriptPath,
+      jestScriptPath: `"${jestScriptPath}"`,
       args,
       env
     };

--- a/server/services/jest-manager/index.ts
+++ b/server/services/jest-manager/index.ts
@@ -144,11 +144,11 @@ export default class JestManager {
   }
 
   getRepoterPath() {
-    return join(__dirname, "./scripts/reporter.js");
+    return `"${join(__dirname, "./scripts/reporter.js")}"`;
   }
 
   getPatchFilePath() {
-    return join(__dirname, "./scripts/patch.js");
+    return `"${join(__dirname, "./scripts/patch.js")}"`;
   }
 
   getPatternForPath(path: string) {

--- a/server/services/jest-manager/index.ts
+++ b/server/services/jest-manager/index.ts
@@ -35,7 +35,7 @@ export default class JestManager {
     this.executeJest(
       [
         "--reporters",
-        this.getRepoterPath(),
+        this.getReporterPath(),
         ...(watch ? [this.getWatchFlag()] : [])
       ],
       true,
@@ -50,7 +50,7 @@ export default class JestManager {
         ...(watch ? [this.getWatchFlag()] : []),
         "--reporters",
         "default",
-        this.getRepoterPath(),
+        this.getReporterPath(),
         "--verbose=false" // this would allow jest to include console output in the result of reporter
       ],
       !watch, // while watching, can not inherit stdio because we want to write back and interact with the process
@@ -64,7 +64,7 @@ export default class JestManager {
         this.getPatternForPath(path),
         "-u",
         "--reporters",
-        this.getRepoterPath()
+        this.getReporterPath()
       ],
       false,
       false
@@ -143,7 +143,7 @@ export default class JestManager {
       });
   }
 
-  getRepoterPath() {
+  getReporterPath() {
     return `"${join(__dirname, "./scripts/reporter.js")}"`;
   }
 


### PR DESCRIPTION
When Majestic runs in a working directory which has spaces in it,

(e.g. `/Users/foo/sunday coding/bar`), it won't load.

In the browser console, the error says:
```
Uncaught TypeError: Cannot read property 'projectRoot' of undefined
    at App (app.tsx:134)
```

Running locally, printing out `stderr` from [project.ts](https://github.com/Raathigesh/majestic/blob/master/server/services/project.ts#L30) gives me something along the lines of:
```
module.js:538
    throw err;
    ^
Error: Cannot find module '/Users/foo/sunday'
    at Function.Module._resolveFilename (module.js:536:15)
```

Similar to issue #88.

I figured out that this is due to the paths weren't being enclosed with quotes, which otherwise would be misinterpreted as multiple arguments ([reference](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)). 

Not sure if this would fix #88 as well since that one might be platform-related, but this at least fixes my own issue. What do you think?

And also, this is my first PR to this repo, and also I am not sure how to write test for this one, would love to hear feedback on the PR. Thanks a lot for Majestic, btw!

P.S. Also, couldn't help but noticed the typo (`getRepoterPath` -> `getReporterPath`), fixing that as well in this PR. Let me know if I should put it separately.