### PR TITLE
Open In Env EDITOR

### DIFF
--- a/server/api/app/resolver.ts
+++ b/server/api/app/resolver.ts
@@ -38,7 +38,7 @@ export default class AppResolver {
 
   @Mutation(returns => String)
   openInEditor(@Arg("path") path: string) {
-    launch(path, "code", (path: string, err: any) => {
+    launch(path, process.env.EDITOR || "code", (path: string, err: any) => {
       console.log("Failed to open file in editor: ", err);
     });
 


### PR DESCRIPTION
Uses the Open In Editor button to open in the editor set by `$EDITOR` if `code` is not valid on your platform.