### PR TITLE
fix(sidebar): missing files after fixing failed tests

### DIFF
--- a/ui/sidebar/index.tsx
+++ b/ui/sidebar/index.tsx
@@ -112,7 +112,7 @@ export default function TestExplorer({
     items
   );
 
-  if (showFailedTests) {
+  if (showFailedTests && failedItems.length) {
     files = filterFailure(files);
   }
 
@@ -239,7 +239,7 @@ export default function TestExplorer({
             >
               <Button
                 size="sm"
-                minimal
+                minimal={!showFailedTests}
                 onClick={() => {
                   setShowFailedTests(!showFailedTests);
                 }}


### PR DESCRIPTION
This closes #115 (my bad, I referenced the wrong issue id previously).

I changed the code to such that it will only filter the failed test files when there are actually failed items in the list (because otherwise it would filter the files to empty). Also another small fix on the UI to highlight the failed test toggle button when activated.

This fixes the issue as far as the use case in #115 is concerned, but if it doesn't, let me know! Thanks for this awesome tool btw.