### PR TITLE
fix(pane2): incorrect max width overflows the browser size

### DIFF
--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -103,6 +103,7 @@ export default function App() {
         split="vertical"
         primary="second"
         pane1Style={{ minWidth: "300px" }}
+        pane2Style={{ maxWidth: "calc(100% - 300px)" }}
       >
         <Sidebar
           workspace={workspace}


### PR DESCRIPTION
This is just just a minor thing I noticed. When resizing the pane to the left, exceeding the first pane's minimum width, the second pane's width keeps increasing, eventually overflows the browser viewport. See the gif for details:

![May-05-2019 16-15-26](https://user-images.githubusercontent.com/8046636/57190829-7788d100-6f51-11e9-83df-8b18bc51277b.gif)

I think both of the panes need to fill up the viewport responsively (since there is no horizontal scrollbar as well). So, my idea is that the second pane should not exceed 100% - 300px in width, since the first pane has a minimum width of 300px.

Let me know what you think! Thank you.

