### PR TITLE
Reassigned shortcut keys for browser compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ You can configure Majestic by adding `majestic` key to `package.json`.
 
 ### Shortcut keys
 
-`ctrl+t` - run all tests
+`alt+t` - run all tests
 
-`ctrl+enter` - run selected file
+`alt+enter` - run selected file
 
-`ctrl+w` - watch
+`alt+w` - watch
 
-`ctrl+s` - search
+`alt+s` - search
 
 `escape` - close search
 

--- a/ui/hooks/use-keys.ts
+++ b/ui/hooks/use-keys.ts
@@ -6,7 +6,7 @@ export function hasKeys(expectedKeys: string[], pressedKeys: Map<String, boolean
 
 export default function useKeys() {
   const [keys, setKeys] = useState(new Map());
-  const hotKeys = ["Control", "Enter", "Escape", "s", "t", "w"];
+  const hotKeys = ["Alt", "Enter", "Escape", "s", "t", "w"];
 
   function downHandler({ key }:KeyboardEvent) {
     // only update state for keys we are watching

--- a/ui/sidebar/index.tsx
+++ b/ui/sidebar/index.tsx
@@ -138,13 +138,13 @@ export default function TestExplorer({
 
   const isRunning = runnerStatus && runnerStatus.running;
   const keys = useKeys();
-  if (hasKeys(["Control", "t"], keys)) {
+  if (hasKeys(["Alt", "t"], keys)) {
     run();
-  } else if (hasKeys(["Control", "w"], keys)) {
+  } else if (hasKeys(["Alt", "w"], keys)) {
     if (runnerStatus) {
       handleSetWatchModel(!runnerStatus.watching);
     }
-  } else if (hasKeys(["Control", "s"], keys)) {
+  } else if (hasKeys(["Alt", "s"], keys)) {
     onSearchOpen();
   }
 

--- a/ui/test-file/index.tsx
+++ b/ui/test-file/index.tsx
@@ -101,7 +101,7 @@ function TestFile({ selectedFilePath, isRunning, projectRoot, onStop }: Props) {
     item => item.parent === null
   );
   const keys = useKeys();
-  if (hasKeys(["Control", "Enter"], keys)) {
+  if (hasKeys(["Alt", "Enter"], keys)) {
     runFile();
   }
   return (


### PR DESCRIPTION
Addresses issue #150, also relevant to #124. 

This is a very minor change to prevent keyboard shortcuts from firing browser commands (such as save). If anyone who isn't using Chrome is reading, let me know if it looks like these new shortcuts will cause problems in other browsers, and I will change them.

It's worth noting that there seems to be a keyboard repeat issue with the watch shortcut. I t looks like the logic is triggering on every render when the keys are held down, requiring a very quick key press to keep it in watch mode. I can create a bug if you'd like.