### PR TITLE
✨ Pretty Printing HTML in console.logs.

### DIFF
--- a/ui/test-file/console-panel/index.tsx
+++ b/ui/test-file/console-panel/index.tsx
@@ -19,12 +19,13 @@ const Header = styled.div`
   margin-bottom: 5px;
 `;
 
-const Content = styled.div`
+const Content = styled.pre`
   display: flex;
   margin-bottom: 3px;
   font-size: 12px;
   border-radius: 3px;
   padding: 4px;
+  font-family: monospace;
 `;
 
 const Logs = styled.div`
@@ -65,7 +66,7 @@ export default function ConsolePanel({ consoleLogs }: Props) {
     <Container>
       <Header>Console logs from the file</Header>
       <Logs>
-        {consoleLogs.map(log => {
+        {consoleLogs.map((log, index) => {
           let result = log.message;
           try {
             result = eval("(" + log.message + ")");
@@ -75,7 +76,7 @@ export default function ConsolePanel({ consoleLogs }: Props) {
 
           if (typeof result === "string") {
             return (
-              <Content>
+              <Content key={index}>
                 {getIcon(log.type)}
                 {result}
               </Content>


### PR DESCRIPTION
 Use `pre` tag to properly format HTML
🚨 Add `index` as key to `map` inside `console-panel/index.tsx`. This is to get rid of the error message in the console. Since we don't have any identifier for each log. React anyway defaults to using index as key when not explicitly given a key. 

Often times when working with tests I have to do `console.log(component.debug()` which outputs a prettified html code onto the console. Majestic however shows the whole component in a single line which can be hard to debug. 

Before: 
![image](https://user-images.githubusercontent.com/10240002/67658170-d702ef00-f97e-11e9-8886-51a82782bb02.png)


After: 
![image](https://user-images.githubusercontent.com/10240002/67659194-ce5fe800-f981-11e9-9240-f0ad161d0037.png)

