### PR TITLE
🚛 Upgrade babel-plugin-styled-components to 1.10.6 from 1.8.0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,6 +13,7 @@
   "plugins": [
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     ["@babel/plugin-proposal-class-properties", { "loose": true }],
-    "@babel/plugin-proposal-object-rest-spread"
+    "@babel/plugin-proposal-object-rest-spread",
+    "babel-plugin-styled-components"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "apollo-utilities": "^1.0.21",
     "awesome-typescript-loader": "^5.2.1",
     "babel-loader": "^8.0.2",
-    "babel-plugin-styled-components": "^1.8.0",
+    "babel-plugin-styled-components": "^1.10.6",
     "body-parser": "^1.18.3",
     "chokidar": "^2.0.4",
     "chrome-launcher": "^0.10.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,7 +1575,7 @@ babel-loader@^8.0.2:
     mkdirp "^0.5.1"
     util.promisify "^1.0.0"
 
-"babel-plugin-styled-components@>= 1", babel-plugin-styled-components@^1.8.0:
+"babel-plugin-styled-components@>= 1":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz#ff1f42ad2cc78c21f26b62266b8f564dbc862939"
   integrity sha512-sQVKG8irFXx14ZfaK1bBePirfkacl3j8nZwSZK+ZjsbnadRHKQTbhXbe/RB1vT6Vgkz45E+V95LBq4KqdhZUNw==
@@ -1584,6 +1584,16 @@ babel-loader@^8.0.2:
     "@babel/helper-module-imports" "^7.0.0"
     babel-plugin-syntax-jsx "^6.18.0"
     lodash "^4.17.10"
+
+babel-plugin-styled-components@^1.10.6:
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.6.tgz#f8782953751115faf09a9f92431436912c34006b"
+  integrity sha512-gyQj/Zf1kQti66100PhrCRjI5ldjaze9O0M3emXRPAN80Zsf8+e1thpTpaXJXVHXtaM4/+dJEgZHyS9Its+8SA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
 
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"


### PR DESCRIPTION
🚨 Add babel-plugin-styled-components to `.babelrc`
🚨 Update `yarn.lock`

Sorry if it was intentional to not have this plugin in `.babelrc`.

Feel free to close this PR if you think it doesn't add value!