### PR TITLE
support optional chaining in unit test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-decorators": "^7.1.2",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+    "@babel/plugin-proposal-optional-chaining": "^7.8.3",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",

--- a/server/services/ast/parser.ts
+++ b/server/services/ast/parser.ts
@@ -7,6 +7,6 @@ export function parse(path: string, code: string) {
 
   return parser.parse(code, {
     sourceType: "module",
-    plugins: ["jsx", "classProperties", additionalPlugin]
+    plugins: ["jsx", "classProperties", "optionalChaining", additionalPlugin]
   });
 }


### PR DESCRIPTION
with a pointer from @raathigesh I was able to add support to babel which allows unit tests to contain statements that use the new optional chaining syntax.

This is necessary because Majestic processes the unit test file with a locally configured copy of babel. We had to add the experimental plugin for optional chaining to babel.

This fixes issue #164