### PR TITLE
Collapsable ui

### DIFF
--- a/server/services/ast/idManager.ts
+++ b/server/services/ast/idManager.ts
@@ -1,0 +1,88 @@
+// This file manages a cache of Ids. The purpose for this cache in Majestic is to 
+// maintain consistent ids for test and describe blocks that do not change name between
+// file reloads. By maintaining consistent Ids for the same blocks, we can do things in 
+// the UI like persistent open/collapse state
+//
+// How this works: Each describe block within a file and the file itself gets its own IdManager
+// The IdManager maintains the list of Ids for that block. These could be Ids of other describe
+// blocks, or they could be Ids of the tests themselves. The IdManager is also responsible for
+// handing out the ids so that it can then associate the Id with the object.
+//
+// managing the IdManagers is done with the IdManagerFactory. It keeps a cache of the IdManagers
+// and you can lookup/create an IdManager based on an Id or file path.
+//
+// How to use these classes:
+//
+// When loading in a file, call IdManagerFactory.getManagerForFile with the file's full path
+// this will return an IdManger to use for the file. Set this as the current IdManager
+//
+// when finding a describe block, cal IdManagerFactory.getManagerForBlock with the Id of the 
+// describe block, this becomes the current IdManager for everythign in the describe block
+//
+// when finding any type of block and we need an Id for it, we call currentManager.createId
+// it will return the proper Id to use for that element, either an existing one or a new one
+
+import * as nanoid from "nanoid";
+
+interface IdEntry {
+  name: string;
+  id: string;
+}
+
+export class IdManager {
+  private ids: IdEntry[]
+  constructor() {
+    this.ids = [];
+  }
+
+  public createId(name: string): string {
+    for(let e of this.ids) {
+        if (e.name === name) {
+          return e.id;
+        }
+    }
+    // name was not found in the list of Ids so create it
+    let newId = {
+      name,
+      id: nanoid()
+    };
+    this.ids.push(newId);
+    return newId.id;
+  }
+}
+
+interface FileManagerEntry {
+  filePath: string;
+  idManager: IdManager;
+}
+export class IdManagerFactory {
+  static describeManagers: {key: string};
+  static fileManagers: FileManagerEntry[];
+
+  static init() {
+    IdManagerFactory.describeManagers = {} as {key: string};
+    IdManagerFactory.fileManagers = [];
+  }
+
+  static getManagerForBlock(id: string): IdManager {
+    let existingManager = IdManagerFactory.describeManagers[id];
+    if (existingManager === undefined) {
+      existingManager = new IdManager();
+      IdManagerFactory.describeManagers[id] = existingManager;
+    }
+    return existingManager;
+  }
+  static getManagerForFile(filePath: string): IdManager {
+    for(let e of IdManagerFactory.fileManagers) {
+      if (e.filePath === filePath) return e.idManager;
+    }
+    let newManager = {
+      filePath,
+      idManager: new IdManager()
+    };
+    IdManagerFactory.fileManagers.push(newManager);
+    return newManager.idManager;
+  }
+}
+
+IdManagerFactory.init();

--- a/ui/test-file/collapseStore.ts
+++ b/ui/test-file/collapseStore.ts
@@ -1,0 +1,24 @@
+// This static class keeps track of the collapse state of every describe block that is shown in the UI.
+// It starts empty and grows with each describe block that the user collapses or expands. 
+// If a describe block has never been collapsed it does not have an entry in the strucure and isCollapsed will
+// always return false. This allows us to get away with an empty structure to start with.
+// If we ever add Redux to the product, then this can move into Redux
+
+export class CollapseStore {
+  static store: {[key: string]: boolean}
+
+  static init() {
+    CollapseStore.store = {} as {[key: string]: boolean};
+  }
+
+  static isCollapsed(id: string): boolean {
+    return CollapseStore.store[id] === true;
+  }
+
+  static setState(id: string, state: boolean) {
+    CollapseStore.store[id] = state;
+  }
+}
+
+// Create the global instance of the store.
+CollapseStore.init();

--- a/ui/test-file/test-item.tsx
+++ b/ui/test-file/test-item.tsx
@@ -1,10 +1,11 @@
-import React, { Fragment } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import { TestFileItem } from "./transformer";
 import { TestFileResult } from "../../server/api/workspace/test-result/file-result";
 import TestIndicator from "./test-indicator";
 import { color, space } from "styled-system";
 import * as Convert from "ansi-to-html";
+import { CollapseStore } from "./collapseStore";
 
 const convert = new Convert({
   colors: {
@@ -19,6 +20,17 @@ function getResults(item: TestFileItem, testResult: TestFileResult) {
   }
 
   return testResult.testResults.find(result => result.title === item.name);
+}
+
+function childResultStatus (child: TestFileItem, testResult: TestFileResult): boolean {
+  if (child.type === "it") {
+    const childResult = getResults(child, testResult as any);
+    return (childResult == null) || (childResult.status === "passed" || childResult.status === "pending");
+  }
+  if (child.children) {
+    return child.children.every(child => childResultStatus(child, testResult));
+  }
+  return true;
 }
 
 const Container = styled.div`
@@ -62,6 +74,13 @@ const Duration = styled.span`
   color: #fcd101;
 `;
 
+const ViewToggle = styled.div`
+  font-size: 15px;
+  padding-right: 10px;
+  padding-left: 10px;
+  cursor: pointer;
+`;
+
 function escapeHtml(unsafe: string) {
   return unsafe
     .replace(/&/g, "&amp;")
@@ -77,7 +96,7 @@ interface Props {
 }
 
 export default function Test({
-  item: { name, only, children },
+  item: { id, name, only, children },
   item,
   result
 }: Props) {
@@ -85,22 +104,35 @@ export default function Test({
   const isDurationAvailable = testResult && testResult.duration !== undefined;
   const haveFailure = testResult && testResult.failureMessages.length > 0;
   const allChildrenPassing = (children || []).every(child => {
-    if (child.type === "it") {
-      const childResult = getResults(child, result as any);
-      return childResult && childResult.status === "passed";
-    }
-
-    return true;
+    return childResultStatus(child, result as any);
   });
+  
+  const [hideChildren, setHideChildren] = useState(CollapseStore.isCollapsed(id) && allChildrenPassing);
+  useEffect(() => {
+    // we need to use the useEffect hook because the initial value passed to state only gets set when the component is 
+    // created the first time. The useEffect hook will allow us to force the failed describe blocks open when the 
+    // results change. 
+    setHideChildren(CollapseStore.isCollapsed(id) && allChildrenPassing);
+  }, [result]);
 
+  const toggleShowChildern = () => {
+    const newState = !hideChildren;
+    setHideChildren(newState);
+    CollapseStore.setState(id, newState);
+  }
   return (
     <Container>
-      <Content only={only}>
+      <Content only={only} onClick={() => toggleShowChildern()}>
         <Label>
+          { children && children.length > 0 && (
+            <ViewToggle>
+              {hideChildren ? "+" : "-"}
+            </ViewToggle>
+          )}
           <TestIndicator
             status={
-              item.type === "describe" && allChildrenPassing
-                ? "passed"
+              item.type === "describe" 
+                ? ((allChildrenPassing) ? "passed" : "failed")
                 : testResult && testResult.status
             }
             describe={item.type === "describe"}
@@ -123,7 +155,7 @@ export default function Test({
           </FailureMessage>
         )}
       </Content>
-      {children &&
+      {children && !hideChildren &&
         children.map(child => (
           <Test key={child.id} item={child} result={result} />
         ))}


### PR DESCRIPTION
The changes in this branch fix the issue #180. 
There are two parts to the change. The first is changing the server to reuse Id values when it rescans the test file. Before this change the Ids would all be different each rescan. If that behaviour wasn't changed, then each time the rescan happened, the collapsed blocks would spring open. So the first step was to get the back end to reuse Ids. 

The second part is in the UI where I augmented the test-file component to use react hooks to add some state: the collapsed state. I ended up improving the pass/fail status of the describe blocks by recursing the children to create the state. This allowed me to spring open a collapsed block that has a test failure after a test run. Also, now describe blocks that have test failures are coloured red instead of staying green. This allows us to see which blocks contain the failed tests. 
When the user switches back and forth between files, the collapsed state is remembered.

I had assumed this would fix #181 but it does not. I will look at that tomorrow.