### PR TITLE
159 wrap summary

### DIFF
--- a/ui/test-file/summary/index.tsx
+++ b/ui/test-file/summary/index.tsx
@@ -27,6 +27,7 @@ const Container = styled.div<any>`
   justify-content: space-between;
   margin-bottom: 10px;
   overflow: hidden;
+  flex-wrap: wrap;
 `;
 
 const ContainerBG = styled(animated.div)`


### PR DESCRIPTION
This fixes issue #159 where the summary used to push the action 
buttons off the edge of the screen as the screen got smaller. 
Now the action buttons wrap to the next line.