### PR TITLE
186 open snapshot in editor

### DIFF
--- a/server/api/app/resolver.ts
+++ b/server/api/app/resolver.ts
@@ -3,6 +3,7 @@ import * as launch from "launch-editor";
 import { App } from "./app";
 import FileWatcher, { WatcherEvents } from "../../services/file-watcher";
 import { pubsub } from "../../event-emitter";
+import { dirname, basename } from "path";
 
 @Resolver(App)
 export default class AppResolver {
@@ -41,6 +42,18 @@ export default class AppResolver {
     launch(path, process.env.EDITOR || "code", (path: string, err: any) => {
       console.log("Failed to open file in editor. You may need to install the code command to your PATH if you are using VSCode: ", err);
     });
+
+    return "";
+  }
+
+  @Mutation(returns => String)
+  openSnapInEditor(@Arg("path") path: string) {
+    var dir = dirname(path)
+    var file = basename(path);
+
+    var snap = dir + '/__snapshots__/' + file + '.snap'
+    console.log("opening the snapshot:", snap);
+    this.openInEditor(snap);
 
     return "";
   }

--- a/ui/test-file/index.tsx
+++ b/ui/test-file/index.tsx
@@ -89,14 +89,6 @@ function TestFile({ selectedFilePath, isRunning, projectRoot, onStop }: Props) {
     result => result.changeToResult
   );
 
-  const haveSnapshotFailures = ((result && result.testResults) || []).some(
-    testResult => {
-      return (testResult.failureMessages || []).some(failureMessage =>
-        failureMessage.includes("toMatchSnapshot")
-      );
-    }
-  );
-
   const roots = (fileItemResult.items || []).filter(
     item => item.parent === null
   );
@@ -116,7 +108,6 @@ function TestFile({ selectedFilePath, isRunning, projectRoot, onStop }: Props) {
         path={selectedFilePath}
         isRunning={isRunning}
         isLoadingResult={loading}
-        haveSnapshotFailures={haveSnapshotFailures}
         onRun={() => {
           runFile();
         }}

--- a/ui/test-file/summary/index.tsx
+++ b/ui/test-file/summary/index.tsx
@@ -11,10 +11,12 @@ import {
   CheckCircle,
   Frown,
   ZapOff,
-  Circle
+  Circle,
+  Eye
 } from "react-feather";
 import Button from "../../components/button";
 import OPEN_IN_EDITOR from "./open-in-editor.gql";
+import OPEN_SNAP_IN_EDITOR from "./open-snap-in-editor.gql";
 import { Tooltip } from "react-tippy";
 import { useMutation } from "react-apollo-hooks";
 
@@ -127,11 +129,16 @@ export default function FileSummary({
   onRun,
   onStop,
   onSnapshotUpdate,
-  haveSnapshotFailures
 }: Props) {
   const Icon = isRunning ? StopCircle : Play;
 
   const openInEditor = useMutation(OPEN_IN_EDITOR, {
+    variables: {
+      path
+    }
+  });
+
+  const openSnapshotInEditor = useMutation(OPEN_SNAP_IN_EDITOR, {
     variables: {
       path
     }
@@ -188,9 +195,8 @@ export default function FileSummary({
             }}
           />
         </Tooltip>
-        {haveSnapshotFailures && (
           <Tooltip
-            title="Update all snapshots of the file"
+            title="Update all snapshots for this file"
             position="bottom"
             size="small"
           >
@@ -204,7 +210,15 @@ export default function FileSummary({
               Update Snapshot
             </Button>
           </Tooltip>
-        )}
+        <Tooltip title="Open snapshot in editor" size="small" position="bottom">
+          <Button
+            icon={<Eye size={14} />}
+            minimal
+            onClick={() => {
+              openSnapshotInEditor();
+            }}
+          />
+        </Tooltip>
       </ActionPanel>
     </Container>
   );

--- a/ui/test-file/summary/open-snap-in-editor.gql
+++ b/ui/test-file/summary/open-snap-in-editor.gql
@@ -1,0 +1,3 @@
+mutation OpenSnapInEditor($path: String!) {
+  openSnapInEditor(path: $path)
+}


### PR DESCRIPTION
This PR does two things. It implements #186 and #191. 
For  #186, this creates a new button to load the snapshot in the editor so that you can quickly
see the snapshot - useful when writing tests. 

I had created FR #191 because I wanted a way to generate the snapshots, not realizing that the
button was already there. This change makes the button visible all the time. The reason for that
is that there are times when you know the snapshots are out of date and need to be updated.
If you run the tests just to have them fail, it wastes time. Having this button visible all the time
saves time because you can generate the snapshots when you know they are out of date.