### PR TITLE
203 keep last result

### DIFF
--- a/server/api/workspace/resolver.ts
+++ b/server/api/workspace/resolver.ts
@@ -155,7 +155,13 @@ export default class WorkspaceResolver {
   ): Promise<TestFileResult> {
     const payload = event.payload;
     const result = new TestFileResult();
-    if (event.id === Events.TEST_RESULT) {
+    if (event.id === Events.TEST_START) {
+      const existingResults = this.results.getResult(path);
+      if (existingResults) {
+        result.testResults =  existingResults.testResults;
+      }
+    }
+    else if (event.id === Events.TEST_RESULT) {
       result.path = path;
       result.failureMessage = payload.failureMessage;
       result.numPassingTests = payload.numPassingTests;

--- a/server/api/workspace/test-result/file-result.ts
+++ b/server/api/workspace/test-result/file-result.ts
@@ -20,7 +20,7 @@ export class TestFileResult {
   failureMessage: string;
 
   @Field(returns => TestItemResult, { nullable: true })
-  testResults: TestItemResult[];
+  testResults: TestItemResult[] | null;
 
   @Field(returns => ConsoleLog, { nullable: true })
   consoleLogs: ConsoleLog[];

--- a/server/services/results.ts
+++ b/server/services/results.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import { MajesticConfig } from "./types";
 import { spawnSync } from "child_process";
 import { createLogger } from "../logger";
+import { TestFileResult } from "../api/workspace/test-result/file-result";
 
 const log = createLogger("Results");
 
@@ -18,9 +19,7 @@ export interface CoverageSummary {
 export default class Results {
   private projectRoot: string = "";
   private results: {
-    [path: string]: {
-      report?: any;
-    };
+    [path: string]: TestFileResult;
   } = {};
 
   private testStatus: {
@@ -83,7 +82,7 @@ export default class Results {
     }
   }
 
-  public getResult(path: string) {
+  public getResult(path: string): TestFileResult | null {
     return this.results[path] || null;
   }
 

--- a/ui/test-file/index.tsx
+++ b/ui/test-file/index.tsx
@@ -28,6 +28,10 @@ const Container = styled.div<any>`
 const Content = styled.div`
   overflow: auto;
   height: calc(100vh - 118px);
+
+  ${({ dim }: any) => dim && `
+  opacity: .5;
+  `}
 `;
 
 const TestItemsContainer = styled.div`
@@ -128,7 +132,7 @@ function TestFile({ selectedFilePath, isRunning, projectRoot, onStop }: Props) {
           updateSnapshot();
         }}
       />
-      <Content>
+      <Content dim={isUpdating}>
         {result && result.testResults && result.testResults.length === 0 && (
           <ErrorPanel failureMessage={result && result.failureMessage} />
         )}


### PR DESCRIPTION
This addresses issue #201
When a user starts a test run, the old results are still shown, but they are dimmed (50% opacity) while the test is running. When the new test results are available, the new test results replace the old test results.

The difference between this and the old behaviour was that in the old behaviour, the old test results were discarded as soon as the test run started. This causes the user to have to sit there waiting for the test to complete before seeing the information that used to be there before the test started if there were additional test failures that were fixed with the new test run. It led to a waste of developer time.

Note, this is the second attempt to bring these changes over. The first PR attempt was done from a corrupt branch in my fork because of a GitHub bug. This PR is based on a fixed branch in my fork.