### PR TITLE
Add `--listenOn` to listen on IPs other than `localhost`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ You can configure Majestic by adding `majestic` key to `package.json`.
 
 `--version` - Will print the version of Majestic and will exit.
 
+`--listenOn` - Will listen on this IP/host instead of localhost.
+
 ### Shortcut keys
 
 `alt+t` - run all tests

--- a/server/index.ts
+++ b/server/index.ts
@@ -46,7 +46,8 @@ async function main() {
         playground: "/debug"
       },
       async () => {
-        const url = `http://localhost:${port}`;
+        const listenOn = args.listenOn || "localhost";
+        const url = `http://${listenOn}:${port}`;
         console.log(`⚡  Majestic v${pkg.version} is running at ${url} `);
 
         if (args.app) {


### PR DESCRIPTION
This allows listening on `0.0.0.0` from within a container. This is useful when trying to use `docker-compose` to bring up a full set of servers for development. (Apps listening on `localhost` aren't available outside a docker container)