### PR TITLE
escape ansi color codes in string console.logs

### DIFF
--- a/server/services/cli.ts
+++ b/server/services/cli.ts
@@ -1,1 +1,1 @@
-export const root = "/Users/saravieira/projects/dragon/" || process.cwd();
+export const root = process.env.ROOT || process.cwd();

--- a/server/services/cli.ts
+++ b/server/services/cli.ts
@@ -1,1 +1,1 @@
-export const root = process.env.ROOT || process.cwd();
+export const root = "/Users/saravieira/projects/dragon/" || process.cwd();

--- a/ui/test-file/console-panel/index.tsx
+++ b/ui/test-file/console-panel/index.tsx
@@ -40,6 +40,8 @@ const IconWrapper = styled.div`
   margin-top: 1px;
 `;
 
+const cleanAnsiCodes = (str: string) => str.replace(/\x1B\[(\d+)m/g, "");
+
 function getIcon(type: String) {
   let icon = null;
   switch (type) {
@@ -61,6 +63,17 @@ interface Props {
   consoleLogs: ConsoleLog[];
 }
 
+function isHTML(str: string) {
+  var a = document.createElement('div');
+  a.innerHTML = str;
+
+  for (var c = a.childNodes, i = c.length; i--;) {
+    if (c[i].nodeType == 1) return true;
+  }
+
+  return false;
+}
+
 export default function ConsolePanel({ consoleLogs }: Props) {
   return (
     <Container>
@@ -72,6 +85,14 @@ export default function ConsolePanel({ consoleLogs }: Props) {
             result = eval("(" + log.message + ")");
           } catch (e) {
             console.log(e);
+          }
+          if (isHTML(result)) {
+            console.log(result)
+            return <Content key={index}>
+              {getIcon(log.type)}
+
+              <code>{cleanAnsiCodes(result)}</code>
+            </Content>
           }
 
           if (typeof result === "string") {

--- a/ui/test-file/console-panel/index.tsx
+++ b/ui/test-file/console-panel/index.tsx
@@ -63,16 +63,6 @@ interface Props {
   consoleLogs: ConsoleLog[];
 }
 
-function isHTML(str: string) {
-  var a = document.createElement('div');
-  a.innerHTML = str;
-
-  for (var c = a.childNodes, i = c.length; i--;) {
-    if (c[i].nodeType == 1) return true;
-  }
-
-  return false;
-}
 
 export default function ConsolePanel({ consoleLogs }: Props) {
   return (
@@ -86,20 +76,12 @@ export default function ConsolePanel({ consoleLogs }: Props) {
           } catch (e) {
             console.log(e);
           }
-          if (isHTML(result)) {
-            console.log(result)
-            return <Content key={index}>
-              {getIcon(log.type)}
-
-              <code>{cleanAnsiCodes(result)}</code>
-            </Content>
-          }
 
           if (typeof result === "string") {
             return (
               <Content key={index}>
                 {getIcon(log.type)}
-                {result}
+                {(result)}
               </Content>
             );
           }

--- a/ui/test-file/console-panel/index.tsx
+++ b/ui/test-file/console-panel/index.tsx
@@ -81,7 +81,7 @@ export default function ConsolePanel({ consoleLogs }: Props) {
             return (
               <Content key={index}>
                 {getIcon(log.type)}
-                {(result)}
+                {cleanAnsiCodes(result)}
               </Content>
             );
           }


### PR DESCRIPTION
👋 

I have been using this tool at work and it's been a life safer, the only issue I have is that when you try to log some HTML because of the ANSI color codes the HTML will show up like this:

<img width="841" alt="Screenshot 2021-07-03 at 15 42 43" src="https://user-images.githubusercontent.com/1051509/124356313-9ceaf580-dc15-11eb-8814-715e32352b50.png">


This PR does a small cleanup in the result and strips all of this and the HTML will show up clean
<img width="907" alt="Screenshot 2021-07-03 at 15 42 31" src="https://user-images.githubusercontent.com/1051509/124356319-ad9b6b80-dc15-11eb-889c-33ff99641e45.png">
